### PR TITLE
Tiny fixes

### DIFF
--- a/nix/default.nix
+++ b/nix/default.nix
@@ -150,7 +150,7 @@ let
 				version = attrs.version or parsedName.version;
 
 				opamRepo = let
-					opamFilename = attrs.opamFile or "*.opam";
+					opamFilename = attrs.opamFile or "*opam";
 					src = attrs.src;
 				in stdenv.mkDerivation {
 					name = "${packageName}-${version}-repo";
@@ -159,7 +159,7 @@ let
 						true
 					'';
 					installPhase = ''
-						dest="$out/packages/${packageName}/${packageName}.${version}/"
+						dest="$out/packages/${packageName}/${packageName}.${version}"
 						mkdir -p "$dest"
 						mv ${opamFilename} "$dest/opam"
 						if [ -f "${src}" ]; then

--- a/nix/default.nix
+++ b/nix/default.nix
@@ -150,7 +150,7 @@ let
 				version = attrs.version or parsedName.version;
 
 				opamRepo = let
-					opamFilename = attrs.opamFile or "*opam";
+					opamFilename = attrs.opamFile or "{opam,*.opam}";
 					src = attrs.src;
 				in stdenv.mkDerivation {
 					name = "${packageName}-${version}-repo";


### PR DESCRIPTION
I needed to make these fixes to build a simple opam package, https://github.com/apatil/crunchium/tree/opam2nix. 
- The trailing slash was resulting in a path like "...//...". 
- "*.opam" was not matching my opam file, which I just called "opam".