### PR TITLE
Support & docs for ad hoc dependencies

### DIFF
--- a/examples/README.md
+++ b/examples/README.md
@@ -15,7 +15,7 @@ If you build an OPAM library in scenario 2, you can add it as a dependency to ot
 If you're building your new project in scenario 1, modify `nix/default.nix` like so:
 ```nix
 let
-  newlib = import 'path/to/newlib';
+  newlib = import path/to/newlib;
 in
 stdenv.mkDerivation {
   # ...
@@ -29,7 +29,7 @@ stdenv.mkDerivation {
 If your new project is another OPAM library that you're building in scenario 2, modify `nix/default/nix` like this:
 ```nix
 let
-  newlib = import 'path/to/newlib';
+  newlib = import path/to/newlib;
 in
 opam2nix.buildOpamPackage rec {
   # ...

--- a/examples/README.md
+++ b/examples/README.md
@@ -8,7 +8,76 @@ This is when your dependencies are in OPAM (and possibly nix), but you just want
 
 This is when you are developing a library to be published on OPAM, but you want to use `opam2nix` to develop / distribute it as well.
 
-Note: this workflow is a little complex, and may change.
+## Using OPAM libraries as dependencies
+
+If you build an OPAM library in scenario 2, you can add it as a dependency to other projects. Say the library's name is `newlib`.
+
+If you're building your new project in scenario 1, modify `nix/default.nix` like so:
+```nix
+let
+  newlib = import 'path/to/newlib';
+in
+stdenv.mkDerivation {
+  # ...
+	buildInputs = [newlib] ++ opam2nix.build {
+    # Dependencies from the public OPAM repo here
+	};
+  # ...
+}
+```
+
+If your new project is another OPAM library that you're building in scenario 2, modify `nix/default/nix` like this:
+```nix
+let
+  newlib = import 'path/to/newlib';
+in
+opam2nix.buildOpamPackage rec {
+  # ...
+  extraPackages = [newlib];
+  # ...
+}
+```
+
+## Using unpublished libraries on Git
+
+If you need to use the bleeding edge of a library, or a library on GitHub that hasn't yet been published to OPAM, you can! Say you want to use the current tip of [ocaml-vdom](https://github.com/LexiFi/ocaml-vdom). In scenario 1, modify `nix/default.nix` like this:
+
+```nix
+let
+	ocaml-vdom = opam2nix.buildOpamPackage rec {
+		version = "0.1";
+		name = "ocaml-vdom-${version}";
+		src = pkgs.fetchgit 	{
+		  "url" = "https://github.com/LexiFi/ocaml-vdom";
+		  "rev" = "c66b7c846804e1c8e15e7d540408c02266d91369";
+		  "sha256" = "1mx7qvlnni2z2rfgbqnnh67kvy6d7gsz698pa9609pwp3p2xg6h1";
+		};
+		ocamlAttr = "ocaml_4_03";
+	};
+in
+stdenv.mkDerivation {
+  # ...
+	buildInputs = [ocaml-vdom] ++ opam2nix.build {
+    # Dependencies from the public OPAM repo here
+	};
+  # ...
+}
+```
+
+In scenario 2, modify it like this:
+
+```nix
+let
+	ocaml-vdom = opam2nix.buildOpamPackage rec {
+    # Same as the example for scenario 1
+	};
+in
+opam2nix.buildOpamPackage rec {
+  # ...
+  extraPackages = [ocaml-vdom];
+  # ...
+}
+```
 
 ### Layout
 

--- a/nix/default.nix
+++ b/nix/default.nix
@@ -144,11 +144,11 @@ let
 		# build a nix derivation from a (local) opam library, i.e. one not in the official repositories
 		buildOpamPackage = attrs:
 			let
-				drvAttrs = removeAttrs attrs ["src" "opamFile" "packageName" "version" "passthru"];
+				drvAttrs = removeAttrs attrs ["src" "opamFile" "packageName" "version" "passthru" "extraPackages"];
 				parsedName = builtins.parseDrvName attrs.name;
 				packageName = attrs.packageName or parsedName.name;
 				version = attrs.version or parsedName.version;
-
+				pkg2repo = pkg: pkg.opam2nix.repo;
 				opamRepo = let
 					opamFilename = attrs.opamFile or "{opam,*.opam}";
 					src = attrs.src;
@@ -171,7 +171,7 @@ let
 				};
 				packageSet = utils.buildPackageSet (drvAttrs // {
 					packages = (attrs.packages or []) ++ [ "${packageName}=${version}" ];
-					extraRepos = (attrs.extraRepos or []) ++ [ opamRepo ];
+					extraRepos = (attrs.extraRepos or []) ++ (builtins.map pkg2repo (attrs.extraPackages or [])) ++ [ opamRepo ];
 				});
 				drv = builtins.getAttr packageName packageSet;
 				passthru = {


### PR DESCRIPTION
This PR adds support for using OPAM libraries built locally with opam2nix as dependencies for other local projects. It also documents how to use GitHub versions of OPAM libraries as dependencies.