### PR TITLE
replace all #!/bin/bash shebangs by #/usr/bin/env bash

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 set -eu
 gup="$(nix-build --show-trace --no-out-link -A gup '<nixpkgs>')"
 [ -n "$gup" ] || exit 1

--- a/repo/update-single.sh
+++ b/repo/update-single.sh
@@ -1,3 +1,3 @@
-#!/bin/bash
+#!/usr/bin/env bash
 set -eu
 "$(dirname "$0")/packages.gup" --unclean "$@"

--- a/repo/update.sh
+++ b/repo/update.sh
@@ -1,3 +1,3 @@
-#!/bin/bash
+#!/usr/bin/env bash
 set -eu
 "$(dirname "$0")/packages.gup" --update "$@"

--- a/script/travis-decrypt.sh
+++ b/script/travis-decrypt.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 set -eu
 pushd keys
 	openssl aes-256-cbc -K "$encrypted_d5f56ec82e6d_key" -iv "$encrypted_d5f56ec82e6d_iv" -in "archive.tgz.enc" -out "archive.tgz" -d

--- a/script/travis-deploy.sh
+++ b/script/travis-deploy.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 set -eu
 
 eval "$(ssh-agent -s)"

--- a/script/travis-update.sh
+++ b/script/travis-update.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 set -eux
 
 git config user.name 'travis-ci';

--- a/script/travis.sh
+++ b/script/travis.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 set -eux
 if [ "$TRAVIS_EVENT_TYPE" != "cron" ]; then
 	: not a cron build, ignoring


### PR DESCRIPTION
/bin/bash is not available in NixOS, notably.

this should fix https://github.com/timbertson/opam2nix-packages/issues/8 (but I could not test entirely because of https://github.com/timbertson/opam2nix-packages/issues/10 )