### PR TITLE
Various fixes

### DIFF
--- a/all.gup
+++ b/all.gup
@@ -1,2 +1,3 @@
 #!bash -eu
 gup -u repo/packages
+gup -u nix/local.tgz

--- a/nix/local.tgz.gup
+++ b/nix/local.tgz.gup
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 set -eu
 # Print the current HEAD or working copy (as a stash)
 # (returns the same hash for unchanged content, due to the overridden GIT_* variables below)

--- a/repo/overrides/install_ocaml_integers_h_once.patch
+++ b/repo/overrides/install_ocaml_integers_h_once.patch
@@ -1,0 +1,14 @@
+diff --git a/Makefile.rules b/Makefile.rules
+index c536845..d51e52a 100644
+--- a/Makefile.rules
++++ b/Makefile.rules
+@@ -80,8 +80,7 @@ INSTALL_CMIS = $($(PROJECT).public:%=$(BUILDDIR)/$($(PROJECT).dir)/%.cmi) \
+ INSTALL_CMTIS = $($(PROJECT).public:%=$(BUILDDIR)/$($(PROJECT).dir)/%.cmti)
+ INSTALL_CMTS = $($(PROJECT).public:%=$(BUILDDIR)/$($(PROJECT).dir)/%.cmt)
+ INSTALL_MLIS = $($(PROJECT).public:%=$($(PROJECT).dir)/%.mli)
+-INSTALL_HEADERS = $(wildcard $($(PROJECT).dir)/*.h) \
+-                  $(package_integers_path)/ocaml_integers.h
++INSTALL_HEADERS = $(wildcard $($(PROJECT).dir)/*.h)
+ THREAD_FLAG = $(if $(filter yes,$($(PROJECT).threads)),-thread)
+ LINK_FLAGS = $(as_needed_flags) $($(PROJECT).link_flags)
+ OCAML_LINK_FLAGS=$(LINK_FLAGS:%=-cclib %)


### PR DESCRIPTION
This is a collection of all the fixes I had to do to build a personal project on nixos:
* overrides to build some packages  (notably a patch I submitted upstream: https://github.com/ocamllabs/ocaml-ctypes/pull/555)
* fix the build of cudf as a dependency of opam2nix
* use clasp from nixpkgs instead of the current broken derivation
* fix a shebang error
etc.
finally, lauching `gup` modified some files in the repo, I committed theses modifications.