### PR TITLE
Get rid of lib.passthru as it was deprecated

### DIFF
--- a/nix/default.nix
+++ b/nix/default.nix
@@ -213,7 +213,7 @@ let
 					};
 				} // (attrs.passthru or {});
 			in
-			lib.addPassthru drv passthru;
+			lib.extendDerivation true passthru drv;
 	};
 
 	impl = stdenv.mkDerivation {


### PR DESCRIPTION
Removed in https://github.com/NixOS/nixpkgs/commit/7b2cf5b12ee972888f987d9c0ca7a7c09a08c0d7. Workaround taken from deprecation message (see that commit).

CC @cgibbard