### PR TITLE
Make the usage of types a little stricter, and fix a bug related to confusion of them.

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,12 @@ One you've copied `release.nix` as `opam2nix-packages.nix`, you can use it like 
     # and include each direct dependency in your `buildInputs`. This will
     # include the `ocaml` dependency:
     mkDerivation {
-      buildInputs = opam2nix.build { packages = ["lwt"]; };
+      buildInputs = opam2nix.build {
+        packages = [
+          { name = "lwt"; }
+          { name = "irmin"; constraint = "=1.3.2"; }
+        ];
+      };
       ( ... )
     };
 
@@ -41,7 +46,7 @@ One you've copied `release.nix` as `opam2nix-packages.nix`, you can use it like 
 
 The utility `buildPackageSet` is very useful for re-exposing all transitive ocaml dependencies for debugging purposes:
 
-    passThru.ocamlPackages = opam2nix.buildPackageSet { packages = ["lwt"]' };
+    passThru.ocamlPackages = opam2nix.buildPackageSet { packages = [ { name = "lwt"; } ]' };
 
 This can be used with e.g. `nix-build -A ocamlPackages.lwt default.nix` if you need to build an individual dependency (but in your project's configuration; i.e. taking all optional dependencies and constraints into account). It accepts all the same arguments as `build` and produces an object with keys for every transitive dependency, rather than a list of direct dependencies.
 
@@ -54,7 +59,7 @@ accepted by the lower level `selectionsFile` and `importSelectionsFile` function
     - `ocamlAttr`: defaults to "ocaml"
     - `ocamlVersion`: default is extracted from the derivaiton name of `pkgs.<ocamlAttr>`, should rarely need to be overriden
     - `basePackages`: defaults to `["base-unix" "base-bigarray" "base-threads"]`, which is hacky.
-    - `packages`: string list of package names
+    - `packages`: list of records with a name and optional constraint field.
     - `args`: extra list of string arguments to pass to the `opam2nix` tool (default `[]`)
     - `extraRepos`: extra list of string arguments to pass to the `opam2nix` tool (default `[]`)
 

--- a/nix/default.nix
+++ b/nix/default.nix
@@ -111,7 +111,7 @@ let
 
 		# builds a nix repo from an opam repo. Doesn't allow for customisation like
 		# overrides etc, but useful for adding non-upstreamed opam packages into the world
-		buildNixRepo = opamRepo: runCommand "opam2nix-repo" {} ''
+		buildNixRepo = opamRepo: runCommand "opam2nix-${opamRepo.name}" {} ''
 			mkdir -p "$out/packages"
 			env OCAMLRUNPARAM=b ${impl}/bin/opam2nix generate --src "${opamRepo}" --cache .cache --dest "$out/packages" '*'
 			echo 'import ./packages' > "$out/default.nix"

--- a/nix/default.nix
+++ b/nix/default.nix
@@ -153,7 +153,7 @@ let
 			[selections.ocaml] ++ (utils.packagesOfSelections specs selections);
 
 		# Takes a single spec and only returns a single selected package matching that.
-		buildPackageSpec = spec: args: builtins.getAttr name (utils.buildPackageSet ({ specs = [spec]; } // args));
+		buildPackageSpec = spec: args: builtins.getAttr spec.name (utils.buildPackageSet ({ specs = [spec]; } // args));
 
 		# Like `buildPackageSpec` but only returns the single selected package.
 		buildPackage = name: buildPackageConstraint { inherit name; };

--- a/nix/default.nix
+++ b/nix/default.nix
@@ -196,7 +196,7 @@ let
 
 				opamAttrs = (drvAttrs // {
 					# `specs` is undocumented, left for consistency
-					specs = (attrs.extraPackages or attrs.specs or [])
+					specs = (attrs.specs or [])
 					  ++ [ { name = packageName; constraint = "=" + version; } ];
 					extraRepos = (attrs.extraRepos or []) ++ [ opamRepo ];
 				});

--- a/nix/single.nix
+++ b/nix/single.nix
@@ -2,7 +2,7 @@
 let
 	pkgs = import <nixpkgs> {};
 	pkgSet = (import ./local.nix {}).buildPackageSet {
-		packages = pkg;
+		specs = [ { name = pkg; } ];
 		ocamlAttr = "ocaml-ng.ocamlPackages_4_05.ocaml";
 	};
 	pkgAttr = if shell == null then pkg else shell;

--- a/test/build.nix
+++ b/test/build.nix
@@ -12,7 +12,7 @@ stdenv.mkDerivation {
 		mkdir -p $out
 		${
 			lib.concatStringsSep "\n" (
-				map (name: "ln -s ${builtins.getAttr name deps} $out/${name}") world.packages
+				map (name: "ln -s ${builtins.getAttr name deps} $out/${name}") world.specs
 			)
 		}
 	'';


### PR DESCRIPTION
cc: @Ericson2314 

As we've been trying to make use of opam2nix in nixifying the build process for a collection of (non-repository) OPAM packages, John and I have had some ideas about how to make things a bit easier to follow and more general. This is a step in that direction (the part about making things easier to follow).