### PR TITLE
Add `buildOpamPackages` for working with multiple local OPAM packages in once package set

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,6 +89,15 @@ accepted by the lower level `selectionsFile` and `importSelectionsFile` function
    - `opamFilename`: the opam file path within `src`
    - also accepts options accepted by either `selectionsFile` or `importSelectionsFile`
 
+ - `opam2nix.buildOpamPackages`: build a package set with many an opam packages
+   from source, rather than from all from a repository
+   - `packagesParsed` a list of (most) of the arguments accepted by `opam2nix.buildOpamPackage`
+     - `src`
+     - `packageName`: the name of OPAM package
+     - `version`: the version of the OPAM package
+     - `opamFilename`: the opam file path within `src`
+   - also accepts options accepted by either `selectionsFile` or `importSelectionsFile`
+
 ## Hacking
 
 This repo contains generated `.nix` expressions, as well as some overrides required for a bunch of packages which don't quite work out of the box.
@@ -137,4 +146,3 @@ Instead, you should call it from your main `.nix` file like so:
       buildInputs = [ selection.lwt ];
       # ...
     }
-

--- a/nix/default.nix
+++ b/nix/default.nix
@@ -191,7 +191,7 @@ let
 		# official repositories.
 		buildOpamPackages = { packagesParsed, ... } @ attrs:
 			let
-				drvAttrs = removeAttrs attrs [ "opamFile" "packagesParsed" ];
+				drvAttrs = removeAttrs attrs [ "packagesParsed" ];
 
 				opamRepo =
 					{ packageName
@@ -227,14 +227,16 @@ let
 
 				makeSpec = { packageName, version, ... }: { name = packageName; constraint = "=${version}"; };
 
+				repos = map opamRepo attrs.packagesParsed;
+
 				opamAttrs = (drvAttrs // {
 					# `specs` is undocumented, left for consistency
 					specs = (attrs.specs or []) ++ map makeSpec attrs.packagesParsed;
-					extraRepos = (attrs.extraRepos or []) ++ map opamRepo attrs.packagesParsed;
+					extraRepos = (attrs.extraRepos or []) ++ repos;
 				});
 			in
 			{
-				repo = opamRepo;
+				inherit repos;
 				packageSet = utils.buildPackageSet opamAttrs;
 				selection = utils.selectionsFileLax opamAttrs;
 			};

--- a/nix/default.nix
+++ b/nix/default.nix
@@ -193,9 +193,14 @@ let
 			let
 				drvAttrs = removeAttrs attrs [ "opamFile" "packagesParsed" ];
 
-				opamRepo = { packageName, version, src }: let
-					opamFilename = attrs.opamFile or "\"$(find . -maxdepth 1 -name 'opam' -o -name '*.opam')\"";
-					in stdenv.mkDerivation {
+				opamRepo =
+					{ packageName
+					, version
+					, src
+					, opamFile ? "\"$(find . -maxdepth 1 -name 'opam' -o -name '*.opam')\""
+					}:
+
+					stdenv.mkDerivation {
 						name = "${packageName}-${version}-repo";
 						inherit src;
 						configurePhase = "true";
@@ -207,7 +212,7 @@ let
 							fi
 							dest="$out/packages/${packageName}/${packageName}.${version}"
 							mkdir -p "$dest"
-							cp ${opamFilename} "$dest/opam"
+							cp ${opamFile} "$dest/opam"
 							if ! [ -f "$dest/opam" ]; then
 								echo "Error: opam file not created"
 								exit 1

--- a/nix/default.nix
+++ b/nix/default.nix
@@ -78,7 +78,6 @@ let
 			# used by `build`, so that you can combine import-time (world) options
 			# with select-time options
 			ocamlAttr ? null,
-			ocaml ? null,
 			ocamlVersion ? null,
 			basePackages ? null,
 			specs,


### PR DESCRIPTION
It's a pretty straightforward generalization of `buildOpamPackage`. We could make one opam repo derivation with all of them but I was trying to minimize churn.

CC @cgibbard