### PR TITLE
add buildOpamPackages

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,7 +89,17 @@ accepted by the lower level `selectionsFile` and `importSelectionsFile` function
    - `packageName`: optional, defaults to the first component of `name`
    - `version`: optional, defaults to the second component of `name`
    - `opamFilename`: the opam file path within `src`
+   - `passthru`: extra passthru attributes, optional
    - also accepts options accepted by either `selectionsFile` or `importSelectionsFile`
+
+ - `opam2nix.buildOpamPackages`: build multiple opam packages from source, rather than from a repository. Takes two arguments:
+   - first, a list of attrsets containing package attributes (meanings and defaults match those described in `buildOpamPackage`):
+     - `src`
+     - `name`
+     - `packageName`: optional, defaults to the first component of `name`
+     - `version`: optional, defaults to the second component of `name`
+     - `opamFilename`: the opam file path within `src`
+   - second, an attrset of additional options accepted by either `selectionsFile` or `importSelectionsFile`
 
 ## Hacking
 

--- a/examples/opam-library/nix/multi.nix
+++ b/examples/opam-library/nix/multi.nix
@@ -1,0 +1,13 @@
+{ pkgs, stdenv, opam2nix }:
+(opam2nix.buildOpamPackages [
+	(rec {
+		version = "0.0.1";
+		name = "hello-${version}";
+		src = ../.;
+		# packageName = "hello"; # default: derived from `name` attribute
+		# opamFile = "hello.opam"; # default: "${packageName}.opam"
+	})
+] {
+
+	ocamlAttr = "ocaml_4_03";
+}).packages.hello

--- a/nix/default.nix
+++ b/nix/default.nix
@@ -187,7 +187,7 @@ let
 				extraPackages = map (path: import (buildNixRepo path)) (world.extraRepos or []);
 			})); in result.opamSelection;
 
-		inherit buildNixRepo packageNames toSpec toSpecs;
+		inherit buildNixRepo packageNames toSpec toSpecs buildOpamPackages;
 
 		# get the implementation of each specified package in the selections.
 		# Selections are the result of `build` (or importing the selection file)
@@ -207,8 +207,6 @@ let
 
 		# Like `buildPackageSpec` but only returns the single selected package.
 		buildPackage = name: buildPackageConstraint { inherit name; };
-
-		buildOpamPackages = packages: drvAttrs: buildOpamPackages packages drvAttrs;
 
 		buildOpamPackage = attrs:
 			with lib;


### PR DESCRIPTION
Alternative to #16 

@Ericson2314 what do you think about this version? Instead of a `packagesParsed` attribute, it accepts two arguments (the first being what your PR called `packagesParsed`, the second being the general selection args). The resulting attributes are also renamed, `repos` -> `opamRepos` and `packageSet` -> `packages`, but I think they should otherwise be the same functionality. Feel free to try it out on your branch and let me know if there are issues.