### PR TITLE
Give people a better first-try experience by using current ocaml

### DIFF
--- a/examples/opam-dependencies/nix/default.nix
+++ b/examples/opam-dependencies/nix/default.nix
@@ -5,7 +5,7 @@ stdenv.mkDerivation {
 	src = ../.;
 	buildInputs = opam2nix.build {
 		specs = opam2nix.toSpecs [ "ocamlbuild" "ocamlfind" "lwt" ];
-		ocamlAttr = "ocaml_4_03";
+		# ocamlAttr = "ocaml_4_03";
 	};
 	buildPhase = ''
 		ocamlbuild -use-ocamlfind hello.native

--- a/examples/opam-library/nix/default.nix
+++ b/examples/opam-library/nix/default.nix
@@ -5,7 +5,7 @@ opam2nix.buildOpamPackage rec {
 	src = ../.;
 
 	# opam specific settings:
-	ocamlAttr = "ocaml_4_03";
+	# ocamlAttr = "ocaml_4_03";
 	# packageName = "hello"; # default: derived from `name` attribute
 	# opamFile = "hello.opam"; # default: "${packageName}.opam"
 }


### PR DESCRIPTION
(not a somewhat broken wrt-opam-libraries ocaml 4.03)

also this cuts down the time required to try the examples by not having to compile ocaml from source at all (instead using the current binary cache of 4.06.1)

Signed-off-by: Tim Dysinger <tim@dysinger.net>