### PR TITLE
use findlib to install num pkg

### DIFF
--- a/repo/overrides/default.nix
+++ b/repo/overrides/default.nix
@@ -107,6 +107,11 @@ in
 		}) opamPackages.lwt;
 
 		nocrypto = disableStackProtection opamPackages.nocrypto;
+		num = overrideAll (x: {
+			installPhase = ''
+				make findlib-install
+			'';
+		}) opamPackages.num;
 		ocamlfind = overrideAll ((import ./ocamlfind) self) opamPackages.ocamlfind;
 		ocb-stubblr = patchAll [./ocb-stubblr/optional-opam.diff] opamPackages.ocb-stubblr; # https://github.com/pqwy/ocb-stubblr/pull/10
 


### PR DESCRIPTION
This package blocks tons of unix-based ocaml libs. It currently tries to install into the ocaml directory in /nix/store instead of into $out.

fix: `make findlib-install` instead of `make install`

Signed-off-by: Tim Dysinger <tim@dysinger.net>