### PR TITLE
add python & nix to the nix-shell (needed)

### DIFF
--- a/shell.nix
+++ b/shell.nix
@@ -3,7 +3,7 @@ let
 	upstream = pkgs.callPackage ./nix/default.nix {};
 	base = (pkgs.nix-pin.api {}).callPackage ./nix/default.nix {};
 	extraPackages = with pkgs;
-		[ gup base.opam2nixBin nix-pin ] ++ (
+		[ python gup base.opam2nixBin nix nix-pin ] ++ (
 			if ci then [ nix-prefetch-scripts ] else []
 		);
 in


### PR DESCRIPTION
closes #32

test by entering with `nix-shell --pure --command 'export NIXPKGS=... ; ./build.sh'`