### PR TITLE
Opam2 testing

### DIFF
--- a/nix/default.nix
+++ b/nix/default.nix
@@ -382,7 +382,7 @@ let
 					) opamPackages;
 			in
 			addPassthru {
-				"4_05" = make "ocamlPackages_4_05";
+				"4_06" = make "ocamlPackages_4_06";
 			} generatedPackages;
 	};
 in

--- a/repo/overrides/default.nix
+++ b/repo/overrides/default.nix
@@ -113,6 +113,7 @@ in
 			'';
 		}) opamPackages.num;
 		ocamlfind = overrideAll ((import ./ocamlfind) self) opamPackages.ocamlfind;
+		ocp-build = addNcurses opamPackages.ocp-build;
 		ocb-stubblr = patchAll [./ocb-stubblr/optional-opam.diff] opamPackages.ocb-stubblr; # https://github.com/pqwy/ocb-stubblr/pull/10
 
 		# fallout of https://github.com/ocaml/opam-repository/pull/6657

--- a/repo/overrides/ocaml.nix
+++ b/repo/overrides/ocaml.nix
@@ -2,7 +2,7 @@
 # Findlib's opam package gets away with it by shadowing the `ocaml` binary on $PATH,
 # but that won't work in a nix build environment
 { makeWrapper, lib }: impl:
-impl.overrideAttrs (orig: {
+lib.overrideDerivation impl (orig: {
 	buildInputs = (orig.buildInputs or []) ++ [ makeWrapper ];
 	postInstall = (orig.postInstall or "") + ''
 		mv $out/bin/ocaml $out/bin/.ocaml.wrapped

--- a/repo/packages.gup
+++ b/repo/packages.gup
@@ -17,7 +17,7 @@ try:
 	opam_repo = os.path.join(here, 'opam-repository')
 	if os.path.exists(opam_repo):
 		print('Using development opam-repo', file=sys.stderr)
-		subprocess.check_call(['gup', '-u', '../nix/src-opam-repository.json'])
+		subprocess.check_call(['gup', '-u', '../nix/release/src-opam-repository.json'])
 
 	cmd = [
 		'nix-shell', os.path.join(here, '../shell.nix'),

--- a/shell.nix
+++ b/shell.nix
@@ -3,7 +3,7 @@ let
 	upstream = pkgs.callPackage ./nix/default.nix {};
 	base = (pkgs.nix-pin.api {}).callPackage ./nix/default.nix {};
 	extraPackages = with pkgs;
-		[ gup base.opam2nixBin nix-pin ] ++ (
+		[ python gup base.opam2nixBin nix nix-pin ] ++ (
 			if ci then [ nix-prefetch-scripts ] else []
 		);
 in

--- a/single-shell.sh
+++ b/single-shell.sh
@@ -2,4 +2,4 @@
 set -eux
 pkg="$1"
 shift
-exec nix-pin shell --no-out-link --path nix/default.nix --show-trace -A opamPackages.4_05."$pkg" "$@"
+exec nix-pin shell --no-out-link --path nix/default.nix --show-trace -A opamPackages.4_06."$pkg" "$@"

--- a/single.sh
+++ b/single.sh
@@ -1,4 +1,4 @@
 #!/usr/bin/env bash
 pkg="$1"
 shift
-exec nix-pin build --no-out-link --path nix/default.nix --show-trace -A opamPackages.4_05."$pkg" "$@"
+exec nix-pin build --no-out-link --path nix/default.nix --show-trace -A opamPackages.4_06."$pkg" "$@"


### PR DESCRIPTION
Here's my changes to opam2nix-testing from today.

* I updated 4_05 to 4_06 (which is the current default ocaml in nixpkgs)
* I updated reference to a gup update json file that was moved to a subdirectory
* I added python & nix to the shell because they are needed in a pure shell
* I added a dependency to `ocp-build` because it needs ncurses to compile
* I had to change overrideAttrs to overrideDerivation in ocaml.nix or it would not work