### PR TITLE
prefer nativeBuldInputs when appropriate

### DIFF
--- a/nix/release/default.nix
+++ b/nix/release/default.nix
@@ -2,6 +2,6 @@ let fetch = pkgs: srcJson: (pkgs.nix-update-source.fetch srcJson).src; in
 {
 	pkgs ? import <nixpkgs> {},
 	opam2nixBin ? pkgs.callPackage "${fetch pkgs ./src-opam2nix.json}/nix" {},
-	opamRepository ? fetch ./src-opam-repository.json,
+	opamRepository ? fetch pkgs ./src-opam-repository.json,
 }:
 pkgs.callPackage "${fetch pkgs ./src.json}/nix" { inherit opam2nixBin opamRepository; }

--- a/nix/release/src-opam2nix.json
+++ b/nix/release/src-opam2nix.json
@@ -3,12 +3,12 @@
     "args": {
       "owner": "timbertson",
       "repo": "opam2nix",
-      "rev": "version-0.4.4",
-      "sha256": "0d8hfri374irmfzac0bcdp8vg92hm9jnlf0sc702dngfqrrrp76y"
+      "rev": "version-0.4.5",
+      "sha256": "1fr0gx9g6g8wr268knx4vl7cp8np2km66vz9vby95x3rczga9r7q"
     },
     "fn": "fetchFromGitHub",
-    "rev": "version-0.4.4",
-    "version": "0.4.4"
+    "rev": "version-0.4.5",
+    "version": "0.4.5"
   },
   "localRepo": "..",
   "owner": "timbertson",

--- a/nix/release/src.json
+++ b/nix/release/src.json
@@ -3,14 +3,14 @@
     "args": {
       "owner": "timbertson",
       "repo": "opam2nix-packages",
-      "rev": "fba41d10989f1bb78cf80eb495140e99a56a1b84",
-      "sha256": "0wrd2k16221ax7sikhi6q34y4qqwqd2hy2yqvdzi6cz0zgs23540"
+      "rev": "136c4c9f07969ebe5ef515a7a793a59c0b27b382",
+      "sha256": "1ccb78bhbpsyh53nangbrkj6hyylz045c1c7ih3fdw6bh83mpw3i"
     },
     "fn": "fetchFromGitHub",
     "localRepo": "/home/tim/dev/ocaml/opam2nix-packages",
     "owner": "timbertson",
     "repo": "opam2nix-packages",
-    "rev": "fba41d10989f1bb78cf80eb495140e99a56a1b84",
+    "rev": "136c4c9f07969ebe5ef515a7a793a59c0b27b382",
     "type": "fetchFromGitHub"
   }
 }

--- a/repo/overrides/default.nix
+++ b/repo/overrides/default.nix
@@ -23,7 +23,7 @@ in
 		"0install" = overrideAll (impl:
 			# disable tests, beause they require additional setup
 			{
-				buildInputs = [ pkgs.makeWrapper ];
+				nativeBuildInputs = [ pkgs.makeWrapper ];
 				configurePhase = ''
 					# ZI makes it very difficult to opt out of tests
 					sed -i -e 's|tests/test\.|__disabled_tests/test.|' ocaml/Makefile
@@ -55,7 +55,7 @@ in
 						sed -i -e 's|"+|"../ocaml/|' "$f"
 					done
 					'';
-				buildInputs = impl.buildInputs ++ [ which ];
+				nativeBuildInputs = (impl.nativeBuildInputs or []) ++ [ which ];
 				# see https://github.com/NixOS/nixpkgs/commit/b2a4eb839a530f84a0b522840a6a4cac51adcba1
 				# if we strip binaries we can get weird errors such that:
 				# /nix/store/.../bin/camlp4orf not found or is not a bytecode executable file
@@ -68,7 +68,8 @@ in
 		let
 			base =
 				overrideAll (impl: {
-					buildInputs = impl.buildInputs ++ [ pkgconfig libffi ncurses ];
+					nativeBuildInputs = (impl.nativeBuildInputs or []) ++ [ pkgconfig ];
+					buildInputs = impl.buildInputs ++ [ libffi ncurses ];
 				}) opamPackages.ctypes;
 			withHeaderPatch =
 			overrideIf (version: lib.elem version [
@@ -88,11 +89,12 @@ in
 		}) opamPackages.gmp-xen;
 
 		lablgtk = overrideAll (impl: {
-			buildInputs = impl.buildInputs ++ [ pkgconfig gtk2.dev ];
+			nativeBuildInputs = (impl.nativeBuildInputs or []) ++ [ pkgconfig ];
+			buildInputs = impl.buildInputs ++ [ gtk2.dev ];
 		}) opamPackages.lablgtk;
 
 		llvm = overrideAll (impl: {
-			buildInputs = impl.buildInputs ++ [ pkgconfig python ];
+			nativeBuildInputs = (impl.nativeBuildInputs or []) ++ [ pkgconfig python ];
 			propagatedBuildInputs = impl.propagatedBuildInputs ++ [ llvm_5 ];
 			installPhase = ''
 				bash -ex install.sh ${llvm_5}/bin/llvm-config $out/lib ${cmake}/bin/cmake make
@@ -120,7 +122,7 @@ in
 		omake = addNcurses opamPackages.omake;
 
 		piqilib = overrideAll (impl: {
-			buildInputs = impl.buildInputs ++ [ which makeWrapper ];
+			nativeBuildInputs = (impl.nativeBuildInputs or []) ++ [ which makeWrapper ];
 			# hack -- for some reason the makefile system ignores OCAMLPATH.
 			configurePhase = ''
 				mkdir .bin
@@ -133,7 +135,7 @@ in
 		solo5-kernel-ukvm = disableStackProtection opamPackages.solo5-kernel-ukvm;
 
 		zarith = overrideAll (impl: {
-			buildInputs = impl.buildInputs ++ [ perl ];
+			nativeBuildInputs = (impl.nativeBuildInputs or []) ++ [ perl ];
 			configurePhase = ''
 				patchShebangs .
 			''+impl.configurePhase;


### PR DESCRIPTION
@dysinger can you confirm this looks right? As I understand it any "build only" deps can move into nativeBuildInputs.

(I expect the generated derivations themselves could also be improved in opam2nix itself, though I'd be surprised if cross-compilation actually worked...)