### PR TITLE
Add package directories to CAML_LD_LIBRARY_PATH

### DIFF
--- a/repo/overrides/ocaml/path-hooks.sh
+++ b/repo/overrides/ocaml/path-hooks.sh
@@ -5,7 +5,7 @@ function ocamlPathSetup {
 		if test -d "$1/lib/stublibs"; then
 			export CAML_LD_LIBRARY_PATH="${CAML_LD_LIBRARY_PATH}${CAML_LD_LIBRARY_PATH:+:}$1/lib/stublibs"
 		else
-			export CAML_LD_LIBRARY_PATH="${CAML_LD_LIBRARY_PATH}${CAML_LD_LIBRARY_PATH:+:}$1/lib"
+			export CAML_LD_LIBRARY_PATH="${CAML_LD_LIBRARY_PATH}${CAML_LD_LIBRARY_PATH:+:}$(find $1/lib -maxdepth 1 -mindepth 1 -printf %p:)$1/lib"
 		fi
 	fi
 }


### PR DESCRIPTION
Dynamic libraries are installed in package directories. So we add these directories to CAML_LD_LIBRARY_PATH.